### PR TITLE
Simplifying the coordinate transformation function

### DIFF
--- a/pySC/core/simulated_commissioning.py
+++ b/pySC/core/simulated_commissioning.py
@@ -252,12 +252,7 @@ class SimulatedCommissioning:
                 for i, ind in enumerate(self.ORD.Magnet):
                     setattr(self.RING[ind], "SupportOffset", offsets[:, i])
                     setattr(self.RING[ind], "SupportRoll", rolls[:, i])
-                    magLength = self.RING[ind].Length
-                    magTheta = self.RING[ind].BendingAngle if hasattr(self.RING[ind], 'BendingAngle') else 0
-                    magnet_offsets = self.RING[ind].SupportOffset + self.RING[ind].MagnetOffset
-                    magnet_rolls = np.roll(self.RING[ind].MagnetRoll + self.RING[ind].SupportRoll, -1)  # z,x,y -> x,y,z
-                    self.RING[ind].T1, self.RING[ind].T2, self.RING[ind].R1, self.RING[ind].R2 = SCgetTransformation(
-                        magnet_offsets, magnet_rolls, magTheta, magLength, refPoint="entrance")
+                    self.RING[ind] = update_transformation(self.RING[ind])
                     if hasattr(self.RING[ind], 'MasterOf'):
                         for child_ind in self.RING[ind].MasterOf:
                             for field in ("T1", "T2", "R1", "R2"):

--- a/pySC/core/simulated_commissioning.py
+++ b/pySC/core/simulated_commissioning.py
@@ -19,7 +19,7 @@ from pySC.core.constants import (BPM_ERROR_FIELDS, RF_ERROR_FIELDS, RF_PROPERTIE
 from pySC.utils import logging_tools
 from pySC.utils.at_wrapper import findspos
 from pySC.utils.classdef_tools import update_double_ordinates, add_padded, intersect, randn_cutoff, s_interpolation
-from pySC.utils.sc_tools import SCrandnc, SCscaleCircumference, SCgetTransformation
+from pySC.utils.sc_tools import SCrandnc, SCscaleCircumference, update_transformation
 
 LOGGER = logging_tools.get_logger(__name__)
 

--- a/pySC/utils/matlab_index.py
+++ b/pySC/utils/matlab_index.py
@@ -16,6 +16,7 @@ from numpy import ndarray
 
 from pySC.core.beam import beam_transmission, bpm_reading, generate_bunches
 from pySC.core.simulated_commissioning import SimulatedCommissioning
+from pySC.core.classes import DotDict
 from pySC.core.lattice_setting import (set_cavity_setpoints, set_magnet_setpoints,
                                        set_cm_setpoints, get_cm_setpoints, SCcronoff as cronoff)
 from pySC.correction.bba import SCBBA as bba
@@ -36,7 +37,7 @@ from pySC.plotting.plot_phase_space import plot_phase_space
 from pySC.plotting.plot_support import plot_support
 from pySC.utils import logging_tools
 from pySC.utils.sc_tools import SCgetOrds as get_ords, SCgetPinv as get_pinv, SCrandnc as randnc, \
-    SCscaleCircumference as scale_circumference, SCgetTransformation as transform, SCmultipolesRead as read_multipoles
+    SCscaleCircumference as scale_circumference, update_transformation, SCmultipolesRead as read_multipoles
 
 LOGGER = logging_tools.get_logger(__name__)
 LOGGER.warn("Matlab_index imported: \n"
@@ -166,7 +167,14 @@ def SCgetSupportRoll(SC: SimulatedCommissioning, s: ndarray) -> ndarray:
 
 
 def SCgetTransformation(dx, dy, dz, ax, ay, az, magTheta, magLength, refPoint='center'):
-    return transform(np.array([dx, dy, dz]), np.array([ax, ay, az]), magTheta, magLength, refPoint=refPoint)
+    if refPoint == 'center':
+        raise NotImplementedError("framework works with 'entrance' reference point")
+    fake_element = DotDict(
+        dict(Length=magLength, BendingAngle=magTheta, SupportOffset=np.zeros(3), SupportRoll=np.zeros(3),
+             MagnetOffset=np.array([dx, dy, dz]),
+             MagnetRoll=np.roll(np.array([ax, ay, az]), 1)))  # inside the function, it will be rolled back
+    fake_element = update_transformation(fake_element)
+    return fake_element.T1, fake_element.T2, fake_element.R1, fake_element.R2
 
 
 def SCinit(RING: Lattice) -> SimulatedCommissioning:

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -1,0 +1,83 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+
+from pySC.utils.sc_tools import update_transformation, rotation
+from pySC.core.classes import DotDict
+
+
+def test_compare_transformation(element):
+    print("\n")
+    print(element)
+    ref_element = element.deepcopy()
+    magLength = element.Length
+    magTheta = element.BendingAngle if hasattr(element, 'BendingAngle') else 0
+    magnet_offsets = element.SupportOffset + element.MagnetOffset
+    magnet_rolls = np.roll(element.MagnetRoll + element.SupportRoll, -1)  # z,x,y -> x,y,z
+    T1, T2, R1, R2 = _sc_get_transformation(magnet_offsets, magnet_rolls, magTheta, magLength, refPoint="entrance")
+    ref_element = update_transformation(ref_element)
+    assert_allclose(ref_element.T1, T1)
+    assert_allclose(ref_element.R1, R1)
+    assert_allclose(ref_element.R2, R2)
+    assert_allclose(ref_element.T2, T2)
+
+
+def _sc_get_transformation(offsets, rolls, magTheta, magLength, refPoint='center'):
+    xAxis = np.array([1, 0, 0])
+    yAxis = np.array([0, 1, 0])
+    zAxis = np.array([0, 0, 1])
+    RX = rotation(rolls)
+    OP = offsets[:]
+    if refPoint == 'center':
+        RB2 = rotation([0, -magTheta/2, 0])
+        RX = np.dot(RB2, np.dot(RX, RB2.T))
+        OP = np.dot(RB2, OP) + np.dot(np.eye(3)-RX, np.dot(RB2, zAxis)) * magLength * (1/2 if magTheta == 0 else np.sin(magTheta / 2) / magTheta)
+
+    for face in range(2):
+        if face == 0:
+            R = RX
+            XaxiSxyz = np.dot(R, xAxis)
+            YaxiSxyz = np.dot(R, yAxis)
+            ZaxiSxyz = np.dot(R, zAxis)
+            LD = np.dot(ZaxiSxyz, OP)
+            tmp = OP
+        else:
+            RB = rotation([0, -magTheta, 0])
+            R = np.dot(RB.T, np.dot(RX.T, RB))
+            XaxiSxyz = np.dot(RB, xAxis)
+            YaxiSxyz = np.dot(RB, yAxis)
+            ZaxiSxyz = np.dot(RB, zAxis)
+            if magTheta == 0:
+                OPp = np.array([0, 0, magLength])
+            else:
+                Rc = magLength / magTheta
+                OPp = np.array([Rc * (np.cos(magTheta) - 1), 0, magLength * np.sin(magTheta) / magTheta])
+            OOp = np.dot(RX, OPp) + OP
+            OpPp = (OPp - OOp)
+            LD = np.dot(ZaxiSxyz, OpPp)
+            tmp = OpPp
+        tD0 = np.array([-np.dot(tmp, XaxiSxyz), 0, -np.dot(tmp, YaxiSxyz), 0, 0, 0])
+        T0 = np.array([LD * R[2, 0] / R[2, 2], R[2, 0], LD * R[2, 1] / R[2, 2], R[2, 1], 0, LD / R[2, 2]])
+        T = T0 + tD0
+        LinMat = np.array(
+            [[R[1, 1] / R[2, 2], LD * R[1, 1] / R[2, 2] ** 2, -R[0, 1] / R[2, 2], -LD * R[0, 1] / R[2, 2] ** 2, 0, 0],
+             [0, R[0, 0], 0, R[1, 0], R[2, 0], 0],
+             [-R[1, 0] / R[2, 2], -LD * R[1, 0] / R[2, 2] ** 2, R[0, 0] / R[2, 2], LD * R[0, 0] / R[2, 2] ** 2, 0, 0],
+             [0, R[0, 1], 0, R[1, 1], R[2, 1], 0],
+             [0, 0, 0, 0, 1, 0],
+             [-R[0, 2] / R[2, 2], -LD * R[0, 2] / R[2, 2] ** 2, -R[1, 2] / R[2, 2], -LD * R[1, 2] / R[2, 2] ** 2, 0,
+              1]])
+        if face == 0:
+            R1 = LinMat
+            T1 = np.dot(np.linalg.inv(R1), T)
+        else:
+            R2 = LinMat
+            T2 = T
+    return T1, T2, R1, R2
+
+
+@pytest.fixture
+def element():
+    return DotDict(dict(
+        Length=1, BendingAngle=0.01, SupportOffset=1e-3*np.random.randn(3), MagnetOffset=1e-3 * np.random.randn(3),
+        SupportRoll=1e-3*np.random.randn(3), MagnetRoll=1e-3*np.random.randn(3)))


### PR DESCRIPTION
Now it takes an element as an input and returns it with update `T1`, `T2`, `R1`, and `R2` attributes.
Removed option of reference point in centre as everything (misalignments, etc.) is now relative to the entrance 