### PR TITLE
Correct bug in model and measured ORM

### DIFF
--- a/pySC/core/beam.py
+++ b/pySC/core/beam.py
@@ -47,8 +47,8 @@ def bpm_reading(SC: SimulatedCommissioning, bpm_ords: ndarray = None, calculate_
         bpm_orbits_4d[:, :, :, shot_num], bpm_sums_4d[:, :, :, shot_num] = _real_bpm_reading(SC, tracking_4d, bpm_inds)
 
     # mean_bpm_orbits_3d is 3D (dim, BPM, turn)
-    mean_bpm_orbits_3d = np.ma.average(np.ma.array(bpm_orbits_4d, mask=np.isnan(bpm_orbits_4d)),
-                                       weights=np.ma.array(bpm_sums_4d, mask=np.isnan(bpm_sums_4d)), axis=3).filled(np.nan)
+    mean_bpm_orbits_3d = np.average(np.ma.array(bpm_orbits_4d, mask=np.isnan(bpm_orbits_4d)),
+                                    weights=np.ma.array(bpm_sums_4d, mask=np.isnan(bpm_sums_4d)), axis=3).filled(np.nan)
     # averaging "charge" also when the beam did not reach the location
     mean_bpm_sums_3d = np.nansum(bpm_sums_4d, axis=3) / SC.INJ.nShots
 

--- a/pySC/core/beam.py
+++ b/pySC/core/beam.py
@@ -47,8 +47,8 @@ def bpm_reading(SC: SimulatedCommissioning, bpm_ords: ndarray = None, calculate_
         bpm_orbits_4d[:, :, :, shot_num], bpm_sums_4d[:, :, :, shot_num] = _real_bpm_reading(SC, tracking_4d, bpm_inds)
 
     # mean_bpm_orbits_3d is 3D (dim, BPM, turn)
-    mean_bpm_orbits_3d = np.average(np.ma.array(bpm_orbits_4d, mask=np.isnan(bpm_orbits_4d)),
-                                    weights=np.ma.array(bpm_sums_4d, mask=np.isnan(bpm_sums_4d)), axis=3).filled(np.nan)
+    mean_bpm_orbits_3d = np.ma.average(np.ma.array(bpm_orbits_4d, mask=np.isnan(bpm_orbits_4d)),
+                                       weights=np.ma.array(bpm_sums_4d, mask=np.isnan(bpm_sums_4d)), axis=3).filled(np.nan)
     # averaging "charge" also when the beam did not reach the location
     mean_bpm_sums_3d = np.nansum(bpm_sums_4d, axis=3) / SC.INJ.nShots
 

--- a/pySC/correction/loco.py
+++ b/pySC/correction/loco.py
@@ -2,7 +2,7 @@ import at
 import numpy as np
 import multiprocessing
 from pySC.lattice_properties.response_model import SCgetModelRM, SCgetModelDispersion
-from pySC.core.constants import SETTING_ADD, TRACK_ORB
+from pySC.core.constants import SETTING_ADD, SETTING_ABS, TRACK_ORB
 from pySC.core.beam import bpm_reading
 import matplotlib.pyplot as plt
 from scipy.optimize import least_squares
@@ -71,9 +71,10 @@ def measure_closed_orbit_response_matrix(SC, bpm_ords, cm_ords, dkick=1e-5):
     cnt = 0
     for n_dim in range(2):
         for cm_ord in cm_ords[n_dim]:
+            initial_cm_value = SC.get_cm_setpoints(cm_ord, skewness=bool(n_dim))
             SC.set_cm_setpoints(cm_ord, dkick, skewness=bool(n_dim), method=SETTING_ADD)
             closed_orbits1 = bpm_reading(SC, bpm_ords=bpm_ords)[0]
-            SC.set_cm_setpoints(cm_ord, -dkick, skewness=bool(n_dim), method=SETTING_ADD)
+            SC.set_cm_setpoints(cm_ord, initial_cm_value, skewness=bool(n_dim), method=SETTING_ABS)
             response_matrix[:, cnt] = np.ravel((closed_orbits1 - closed_orbits0) / dkick)
             cnt = cnt + 1
     return response_matrix

--- a/pySC/lattice_properties/response_model.py
+++ b/pySC/lattice_properties/response_model.py
@@ -160,8 +160,8 @@ def SCgetModelRING(SC: SimulatedCommissioning, includeAperture: bool =False) -> 
     ring = SC.IDEALRING.deepcopy()
     for ord in range(len(SC.RING)):
         if hasattr(SC.RING[ord], 'SetPointA') and hasattr(SC.RING[ord], 'SetPointB'):
-            ring[ord].PolynomA = SC.RING[ord].SetPointA
-            ring[ord].PolynomB = SC.RING[ord].SetPointB
+            ring[ord].PolynomA = copy.deepcopy(SC.RING[ord].SetPointA)
+            ring[ord].PolynomB = copy.deepcopy(SC.RING[ord].SetPointB)
             ring[ord].PolynomA[0] = 0.0
             ring[ord].PolynomB[0] = 0.0
         if includeAperture:


### PR DESCRIPTION
One bug fix and one improvement when dealing with the calculation of ORM.

Correction of a bug fix in the response_model.SCgetModelRING function where the elements from the original SC.RING PolynomB[0] is set to zero. This is caused by the mutable nature of SC.RING[ord].SetPointA. It can be avoided with a deepcopy. The bug was observed after all my elements with embedded CM lost their corrector strengths after using the response_model.SCgetModelRING function.

Improvement of the loco.measure_closed_orbit_response_matrix function where the CM setpoints are reverted back to their initial value instead of applying the opposite dkick. If the dkick leads the CM strength to exceed its maximum value specified in its CMlimit attribute, computing the measured ORM changes some CM strengths.